### PR TITLE
Add LinkedIn icon to page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 import { Block, Title, Skill, Graduate, Stack } from '@components'
 import type { NextPage } from 'next'
 import Image from 'next/image'
-import { AiFillGithub } from 'react-icons/ai'
+import { AiFillGithub, AiFillLinkedin } from 'react-icons/ai'
 import Link from 'next/link'
 import { Certificate } from '@components/List/Certificate'
 
@@ -43,13 +43,18 @@ const Page: NextPage = () => {
               )
             })}
             <dd>
-              <Link
-                href="https://github.com/yugo-ibuki"
-                className={'inline-block mt-2 sp:mt-3'}
-                target={'_blank'}
-              >
-                <AiFillGithub size={20} />
-              </Link>
+              <div className="flex gap-2">
+                <Link
+                  href="https://github.com/yugo-ibuki"
+                  className={'inline-block mt-2 sp:mt-3'}
+                  target={'_blank'}
+                >
+                  <AiFillGithub size={25} />
+                </Link>
+                <Link href="" className={'inline-block mt-2 sp:mt-3'} target={'_blank'}>
+                  <AiFillLinkedin size={25} />
+                </Link>
+              </div>
             </dd>
           </dl>
         </div>


### PR DESCRIPTION
The LinkedIn icon has been added alongside the existing Github icon on the page. The size of both icons has been adjusted to ensure consistency. The button for LinkedIn currently has no URL, it will need to be linked in the future.